### PR TITLE
Add Pan param & wave selection labels

### DIFF
--- a/volca-drum/index.html
+++ b/volca-drum/index.html
@@ -45,8 +45,8 @@
                 <p>Select that MIDI interface in the Midi Device Setup (the channel doesn't matter).</p>
                 <p>The patch will be sent to your Volca automatically when the interface is chosen.</p>
                 <p>Make your patch!</p>
-                <p>My preferred way to "save" your patch is by clicking "Create Sharable Patch Link" and saving the link somewhere (and don't forget to share it!). 
-                    You can also save a stream of MIDI CC data which can be played back using a DAW etc. by clicking "Save Patch". You can also save the current 
+                <p>My preferred way to "save" your patch is by clicking "Create Sharable Patch Link" and saving the link somewhere (and don't forget to share it!).
+                    You can also save a stream of MIDI CC data which can be played back using a DAW etc. by clicking "Save Patch". You can also save the current
                     state of the patch as a kit on your Volca.</p>
                 <p>Have fun!</p>
                 <p>If you have questions you can get hold of me on one of many social media platforms:</p>
@@ -55,7 +55,7 @@
                     <li><a href="https://www.facebook.com/OscillatorSink/">Facebook</a></li>
                     <li><a href="https://twitter.com/oscillatorsink">Twitter</a></li>
                 </ul>
-                <p>Oh, and if you want to create your own midi controller you can find the library I build to create this patch editor here: 
+                <p>Oh, and if you want to create your own midi controller you can find the library I build to create this patch editor here:
                     <a href="https://github.com/synthmata/ccynthmata">ccynthmata</a></p>
             </div>
 
@@ -89,236 +89,242 @@
                 <div class="controlitemgroup">
                     <h3>Layer 1</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                             <label for="p1select1wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part one layer one sine voice"></label>
-                            <input 
+                            <input
                                 type="radio" name="p1select1wave" value="0" checked
                                 class="midicctotal" id="p1select1wavesine"
                                 data-midiChannel="1" data-cclsb="14"/>
-                            
+
                             <label for="p1select1wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part one layer one saw voice"></label>
-                            <input 
-                                type="radio" name="p1select1wave" value="26" 
+                            <input
+                                type="radio" name="p1select1wave" value="26"
                                 class="midicctotal" id="p1select1wavesaw"
                                 data-midiChannel="1" data-cclsb="14"/>
-                           
+
                             <label for="p1select1wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part one layer one high pass noise voice"></label>
-                            <input 
-                                type="radio" name="p1select1wave" value="52" 
+                            <input
+                                type="radio" name="p1select1wave" value="52"
                                 class="midicctotal" id="p1select1wavenoisehp"
                                 data-midiChannel="1" data-cclsb="14"/>
-                            
+
                             <label for="p1select1wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part one layer one low pass noise voice"></label>
-                            <input 
-                                type="radio" name="p1select1wave" value="77" 
+                            <input
+                                type="radio" name="p1select1wave" value="77"
                                 class="midicctotal" id="p1select1wavenoiselp"
                                 data-midiChannel="1" data-cclsb="14"/>
-                            
+
                             <label for="p1select1wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part one layer one band pass noise voice"></label>
-                            <input 
-                                type="radio" name="p1select1wave" value="103" 
+                            <input
+                                type="radio" name="p1select1wave" value="103"
                                 class="midicctotal" id="p1select1wavenoisebp"
                                 data-midiChannel="1" data-cclsb="14"/>
-                            
+
                         </div>
-                        <div class="radiogroup">
+                        <label for="modgroup">Pitch Modulator</label>
+                        <div class="radiogroup" id="modgroup">
                             <label for="p1select1modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part one layer one envelope modulation"></label>
-                            <input 
+                            <input
                                 type="radio" name="p1select1mod" value="0" checked
                                 class="midicctotal" id="p1select1modexp"
                                 data-midiChannel="1" data-cclsb="14"/>
 
                             <label for="p1select1modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part one layer one lfo modulation"></label>
-                            <input 
-                                type="radio" name="p1select1mod" value="9" 
+                            <input
+                                type="radio" name="p1select1mod" value="9"
                                 class="midicctotal" id="p1select1modtri"
                                 data-midiChannel="1" data-cclsb="14"/>
 
                             <label for="p1select1modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part one layer one random modulation"></label>
-                            <input 
-                                type="radio" name="p1select1mod" value="18" 
+                            <input
+                                type="radio" name="p1select1mod" value="18"
                                 class="midicctotal" id="p1select1modrand"
                                 data-midiChannel="1" data-cclsb="14"/>
                         </div>
-                        <div class="radiogroup">
+                        <label for="envgroup">Amplitude Envelope Generator</label>
+                        <div class="radiogroup" id="envgroup">
                             <label for="p1select1envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part one layer one attack delay envelope"></label>
-                            <input 
+                            <input
                                 type="radio" name="p1select1env" value="0" checked
                                 class="midicctotal" id="p1select1envad"
                                 data-midiChannel="1" data-cclsb="14"/>
                             <label for="p1select1envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part one layer one exponential envelope"></label>
-                            <input 
-                                type="radio" name="p1select1env" value="3" 
+                            <input
+                                type="radio" name="p1select1env" value="3"
                                 class="midicctotal" id="p1select1envexp"
                                 data-midiChannel="1" data-cclsb="14"/>
                             <label for="p1select1envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part one layer one multi envelope"></label>
-                            <input 
-                                type="radio" name="p1select1env" value="6" 
+                            <input
+                                type="radio" name="p1select1env" value="6"
                                 class="midicctotal" id="p1select1envmulti"
                                 data-midiChannel="1" data-cclsb="14"/>
                         </div>
                         <div class="controller">
                             <label for="p1level1">Level</label>
-                            <input 
-                                class="midiccparam" id="p1level1"  
+                            <input
+                                class="midiccparam" id="p1level1"
                                 data-midiChannel="1" data-cclsb="17"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p1pitch1">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p1pitch1"  
+                            <input
+                                class="midiccparam" id="p1pitch1"
                                 data-midiChannel="1" data-cclsb="26"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1egattack1">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p1egattack1"  
+                            <input
+                                class="midiccparam" id="p1egattack1"
                                 data-midiChannel="1" data-cclsb="20"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1egrelease1">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p1egrelease1"  
+                            <input
+                                class="midiccparam" id="p1egrelease1"
                                 data-midiChannel="1" data-cclsb="23"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1modamt1">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p1modamt1"  
+                            <input
+                                class="midiccparam" id="p1modamt1"
                                 data-midiChannel="1" data-cclsb="29"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1modrate1">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p1modrate1"  
+                            <input
+                                class="midiccparam" id="p1modrate1"
                                 data-midiChannel="1" data-cclsb="46"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
-            
+
                 <!--Part 1 Layer 2-->
-            
+
                 <div class="controlitemgroup">
                     <h3>Layer 2</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                                 <label for="p1select2wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part one layer one sine voice"></label>
-                                <input 
+                                <input
                                     type="radio" name="p1select2wave" value="0" checked
                                     class="midicctotal" id="p1select2wavesine"
                                     data-midiChannel="1" data-cclsb="15"/>
-                                
+
                                 <label for="p1select2wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part one layer one saw voice"></label>
-                                <input 
-                                    type="radio" name="p1select2wave" value="26" 
+                                <input
+                                    type="radio" name="p1select2wave" value="26"
                                     class="midicctotal" id="p1select2wavesaw"
                                     data-midiChannel="1" data-cclsb="15"/>
-                                
+
                                 <label for="p1select2wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part one layer one high pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p1select2wave" value="52" 
+                                <input
+                                    type="radio" name="p1select2wave" value="52"
                                     class="midicctotal" id="p1select2wavenoisehp"
                                     data-midiChannel="1" data-cclsb="15"/>
-                                
+
                                 <label for="p1select2wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part one layer one low pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p1select2wave" value="77" 
+                                <input
+                                    type="radio" name="p1select2wave" value="77"
                                     class="midicctotal" id="p1select2wavenoiselp"
                                     data-midiChannel="1" data-cclsb="15"/>
-                                
+
                                 <label for="p1select2wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part one layer one band pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p1select2wave" value="103" 
+                                <input
+                                    type="radio" name="p1select2wave" value="103"
                                     class="midicctotal" id="p1select2wavenoisebp"
                                     data-midiChannel="1" data-cclsb="15"/>
-                                
+
                             </div>
-                            <div class="radiogroup">
+                            <label for="modgroup">Pitch Modulator</label>
+                            <div class="radiogroup" id="modgroup">
                                 <label for="p1select2modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part one layer one envelope modulation"></label>
-                                <input 
+                                <input
                                     type="radio" name="p1select2mod" value="0" checked
                                     class="midicctotal" id="p1select2modexp"
                                     data-midiChannel="1" data-cclsb="15"/>
-    
+
                                 <label for="p1select2modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part one layer one lfo modulation"></label>
-                                <input 
-                                    type="radio" name="p1select2mod" value="9" 
+                                <input
+                                    type="radio" name="p1select2mod" value="9"
                                     class="midicctotal" id="p1select2modtri"
                                     data-midiChannel="1" data-cclsb="15"/>
-    
+
                                 <label for="p1select2modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part one layer one random modulation"></label>
-                                <input 
-                                    type="radio" name="p1select2mod" value="18" 
+                                <input
+                                    type="radio" name="p1select2mod" value="18"
                                     class="midicctotal" id="p1select2modrand"
                                     data-midiChannel="1" data-cclsb="15"/>
                             </div>
-                            <div class="radiogroup">
+                            <label for="envgroup">Amplitude Envelope Generator</label>
+                            <div class="radiogroup" id="envgroup">
                                 <label for="p1select2envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part one layer one attack delay envelope"></label>
-                                <input 
+                                <input
                                     type="radio" name="p1select2env" value="0" checked
                                     class="midicctotal" id="p1select2envad"
                                     data-midiChannel="1" data-cclsb="15"/>
                                 <label for="p1select2envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part one layer one exponential envelope"></label>
-                                <input 
-                                    type="radio" name="p1select2env" value="3" 
+                                <input
+                                    type="radio" name="p1select2env" value="3"
                                     class="midicctotal" id="p1select2envexp"
                                     data-midiChannel="1" data-cclsb="15"/>
                                 <label for="p1select2envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part one layer one multi envelope"></label>
-                                <input 
-                                    type="radio" name="p1select2env" value="6" 
+                                <input
+                                    type="radio" name="p1select2env" value="6"
                                     class="midicctotal" id="p1select2envmulti"
                                     data-midiChannel="1" data-cclsb="15"/>
                             </div>
                         <div class="controller">
                             <label for="p1level2">Level</label>
-                            <input 
-                                class="midiccparam" id="p1level2"  
+                            <input
+                                class="midiccparam" id="p1level2"
                                 data-midiChannel="1" data-cclsb="18"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p1pitch2">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p1pitch2"  
+                            <input
+                                class="midiccparam" id="p1pitch2"
                                 data-midiChannel="1" data-cclsb="27"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1egattack2">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p1egattack2"  
+                            <input
+                                class="midiccparam" id="p1egattack2"
                                 data-midiChannel="1" data-cclsb="21"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1egrelease2">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p1egrelease2"  
+                            <input
+                                class="midiccparam" id="p1egrelease2"
                                 data-midiChannel="1" data-cclsb="24"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1modamt2">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p1modamt2"  
+                            <input
+                                class="midiccparam" id="p1modamt2"
                                 data-midiChannel="1" data-cclsb="30"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1modrate2">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p1modrate2"  
+                            <input
+                                class="midiccparam" id="p1modrate2"
                                 data-midiChannel="1" data-cclsb="47"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
                 <div class="controlitemgroup">
@@ -326,36 +332,43 @@
                     <div>
                         <div class="controller">
                             <label for="p1send">Wave Guide Send</label>
-                            <input 
-                                class="midiccparam" id="p1send"  
+                            <input
+                                class="midiccparam" id="p1send"
                                 data-midiChannel="1" data-cclsb="103"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1bitred">Bit Reduction</label>
-                            <input 
-                                class="midiccparam" id="p1bitred"  
+                            <input
+                                class="midiccparam" id="p1bitred"
                                 data-midiChannel="1" data-cclsb="49"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1fold">Fold</label>
-                            <input 
-                                class="midiccparam" id="p1fold"  
+                            <input
+                                class="midiccparam" id="p1fold"
                                 data-midiChannel="1" data-cclsb="50"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p1drive">Drive</label>
-                            <input 
-                                class="midiccparam" id="p1drive"  
+                            <input
+                                class="midiccparam" id="p1drive"
                                 data-midiChannel="1" data-cclsb="51"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
+                            <label for="p1pan">Pan</label>
+                            <input
+                                class="midiccparam" id="p1pan"
+                                data-midiChannel="1" data-cclsb="10"
+                                max="127" min="0" type="range" />
+                        </div>
+                        <div class="controller">
                             <label for="p1gain">Gain</label>
-                            <input 
-                                class="midiccparam" id="p1gain"  
+                            <input
+                                class="midiccparam" id="p1gain"
                                 data-midiChannel="1" data-cclsb="52"
                                 max="127" min="0" type="range" />
                         </div>
@@ -372,236 +385,242 @@
                 <div class="controlitemgroup">
                     <h3>Layer 1</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                             <label for="p2select1wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part two layer one sine voice"></label>
-                            <input 
+                            <input
                                 type="radio" name="p2select1wave" value="0" checked
                                 class="midicctotal" id="p2select1wavesine"
                                 data-midiChannel="2" data-cclsb="14"/>
-                            
+
                             <label for="p2select1wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part two layer one saw voice"></label>
-                            <input 
-                                type="radio" name="p2select1wave" value="26" 
+                            <input
+                                type="radio" name="p2select1wave" value="26"
                                 class="midicctotal" id="p2select1wavesaw"
                                 data-midiChannel="2" data-cclsb="14"/>
-                            
+
                             <label for="p2select1wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part two layer one high pass noise voice"></label>
-                            <input 
-                                type="radio" name="p2select1wave" value="52" 
+                            <input
+                                type="radio" name="p2select1wave" value="52"
                                 class="midicctotal" id="p2select1wavenoisehp"
                                 data-midiChannel="2" data-cclsb="14"/>
-                            
+
                             <label for="p2select1wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part two layer one low pass noise voice"></label>
-                            <input 
-                                type="radio" name="p2select1wave" value="77" 
+                            <input
+                                type="radio" name="p2select1wave" value="77"
                                 class="midicctotal" id="p2select1wavenoiselp"
                                 data-midiChannel="2" data-cclsb="14"/>
-                            
+
                             <label for="p2select1wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part two layer one band pass noise voice"></label>
-                            <input 
-                                type="radio" name="p2select1wave" value="103" 
+                            <input
+                                type="radio" name="p2select1wave" value="103"
                                 class="midicctotal" id="p2select1wavenoisebp"
                                 data-midiChannel="2" data-cclsb="14"/>
-                            
+
                         </div>
-                        <div class="radiogroup">
+                        <label for="modgroup">Pitch Modulator</label>
+                        <div class="radiogroup" id="modgroup">
                             <label for="p2select1modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part two layer one envelope modulation"></label>
-                            <input 
+                            <input
                                 type="radio" name="p2select1mod" value="0" checked
                                 class="midicctotal" id="p2select1modexp"
                                 data-midiChannel="2" data-cclsb="14"/>
 
                             <label for="p2select1modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part two layer one lfo modulation"></label>
-                            <input 
-                                type="radio" name="p2select1mod" value="9" 
+                            <input
+                                type="radio" name="p2select1mod" value="9"
                                 class="midicctotal" id="p2select1modtri"
                                 data-midiChannel="2" data-cclsb="14"/>
 
                             <label for="p2select1modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part two layer one random modulation"></label>
-                            <input 
-                                type="radio" name="p2select1mod" value="18" 
+                            <input
+                                type="radio" name="p2select1mod" value="18"
                                 class="midicctotal" id="p2select1modrand"
                                 data-midiChannel="2" data-cclsb="14"/>
                         </div>
-                        <div class="radiogroup">
+                        <label for="envgroup">Amplitude Envelope Generator</label>
+                        <div class="radiogroup" id="envgroup">
                             <label for="p2select1envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part two layer one attack delay envelope"></label>
-                            <input 
+                            <input
                                 type="radio" name="p2select1env" value="0" checked
                                 class="midicctotal" id="p2select1envad"
                                 data-midiChannel="2" data-cclsb="14"/>
                             <label for="p2select1envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part two layer one exponential envelope"></label>
-                            <input 
-                                type="radio" name="p2select1env" value="3" 
+                            <input
+                                type="radio" name="p2select1env" value="3"
                                 class="midicctotal" id="p2select1envexp"
                                 data-midiChannel="2" data-cclsb="14"/>
                             <label for="p2select1envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part two layer one multi envelope"></label>
-                            <input 
-                                type="radio" name="p2select1env" value="6" 
+                            <input
+                                type="radio" name="p2select1env" value="6"
                                 class="midicctotal" id="p2select1envmulti"
                                 data-midiChannel="2" data-cclsb="14"/>
                         </div>
                         <div class="controller">
                             <label for="p2level1">Level</label>
-                            <input 
-                                class="midiccparam" id="p2level1"  
+                            <input
+                                class="midiccparam" id="p2level1"
                                 data-midiChannel="2" data-cclsb="17"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p2pitch1">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p2pitch1"  
+                            <input
+                                class="midiccparam" id="p2pitch1"
                                 data-midiChannel="2" data-cclsb="26"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2egattack1">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p2egattack1"  
+                            <input
+                                class="midiccparam" id="p2egattack1"
                                 data-midiChannel="2" data-cclsb="20"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2egrelease1">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p2egrelease1"  
+                            <input
+                                class="midiccparam" id="p2egrelease1"
                                 data-midiChannel="2" data-cclsb="23"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2modamt1">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p2modamt1"  
+                            <input
+                                class="midiccparam" id="p2modamt1"
                                 data-midiChannel="2" data-cclsb="29"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2modrate1">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p2modrate1"  
+                            <input
+                                class="midiccparam" id="p2modrate1"
                                 data-midiChannel="2" data-cclsb="46"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
-            
+
                 <!--Part 2 Layer 2-->
-            
+
                 <div class="controlitemgroup">
                     <h3>Layer 2</h3>
                     <div>
-                        <div class="radiogroup">
+                      <label for="wavegroup">Sound Source</label>
+                      <div class="radiogroup" id="wavegroup">
                                 <label for="p2select2wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part two layer one sine voice"></label>
-                                <input 
+                                <input
                                     type="radio" name="p2select2wave" value="0" checked
                                     class="midicctotal" id="p2select2wavesine"
                                     data-midiChannel="2" data-cclsb="15"/>
-                                
+
                                 <label for="p2select2wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part two layer one saw voice"></label>
-                                <input 
-                                    type="radio" name="p2select2wave" value="26" 
+                                <input
+                                    type="radio" name="p2select2wave" value="26"
                                     class="midicctotal" id="p2select2wavesaw"
                                     data-midiChannel="2" data-cclsb="15"/>
-                                
+
                                 <label for="p2select2wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part two layer one high pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p2select2wave" value="52" 
+                                <input
+                                    type="radio" name="p2select2wave" value="52"
                                     class="midicctotal" id="p2select2wavenoisehp"
                                     data-midiChannel="2" data-cclsb="15"/>
-                                
+
                                 <label for="p2select2wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part two layer one low pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p2select2wave" value="77" 
+                                <input
+                                    type="radio" name="p2select2wave" value="77"
                                     class="midicctotal" id="p2select2wavenoiselp"
                                     data-midiChannel="2" data-cclsb="15"/>
-                                
+
                                 <label for="p2select2wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part two layer one band pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p2select2wave" value="103" 
+                                <input
+                                    type="radio" name="p2select2wave" value="103"
                                     class="midicctotal" id="p2select2wavenoisebp"
                                     data-midiChannel="2" data-cclsb="15"/>
-                                
+
                             </div>
-                            <div class="radiogroup">
+                            <label for="modgroup">Pitch Modulator</label>
+                            <div class="radiogroup" id="modgroup">
                                 <label for="p2select2modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part two layer one envelope modulation"></label>
-                                <input 
+                                <input
                                     type="radio" name="p2select2mod" value="0" checked
                                     class="midicctotal" id="p2select2modexp"
                                     data-midiChannel="2" data-cclsb="15"/>
-    
+
                                 <label for="p2select2modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part two layer one lfo modulation"></label>
-                                <input 
-                                    type="radio" name="p2select2mod" value="9" 
+                                <input
+                                    type="radio" name="p2select2mod" value="9"
                                     class="midicctotal" id="p2select2modtri"
                                     data-midiChannel="2" data-cclsb="15"/>
-    
+
                                 <label for="p2select2modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part two layer one random modulation"></label>
-                                <input 
-                                    type="radio" name="p2select2mod" value="18" 
+                                <input
+                                    type="radio" name="p2select2mod" value="18"
                                     class="midicctotal" id="p2select2modrand"
                                     data-midiChannel="2" data-cclsb="15"/>
                             </div>
-                            <div class="radiogroup">
+                            <label for="envgroup">Amplitude Envelope Generator</label>
+                            <div class="radiogroup" id="envgroup">
                                 <label for="p2select2envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part two layer one attack delay envelope"></label>
-                                <input 
+                                <input
                                     type="radio" name="p2select2env" value="0" checked
                                     class="midicctotal" id="p2select2envad"
                                     data-midiChannel="2" data-cclsb="15"/>
                                 <label for="p2select2envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part two layer one exponential envelope"></label>
-                                <input 
-                                    type="radio" name="p2select2env" value="3" 
+                                <input
+                                    type="radio" name="p2select2env" value="3"
                                     class="midicctotal" id="p2select2envexp"
                                     data-midiChannel="2" data-cclsb="15"/>
                                 <label for="p2select2envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part two layer one multi envelope"></label>
-                                <input 
-                                    type="radio" name="p2select2env" value="6" 
+                                <input
+                                    type="radio" name="p2select2env" value="6"
                                     class="midicctotal" id="p2select2envmulti"
                                     data-midiChannel="2" data-cclsb="15"/>
                             </div>
                         <div class="controller">
                             <label for="p2level2">Level</label>
-                            <input 
-                                class="midiccparam" id="p2level2"  
+                            <input
+                                class="midiccparam" id="p2level2"
                                 data-midiChannel="2" data-cclsb="18"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p2pitch2">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p2pitch2"  
+                            <input
+                                class="midiccparam" id="p2pitch2"
                                 data-midiChannel="2" data-cclsb="27"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2egattack2">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p2egattack2"  
+                            <input
+                                class="midiccparam" id="p2egattack2"
                                 data-midiChannel="2" data-cclsb="21"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2egrelease2">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p2egrelease2"  
+                            <input
+                                class="midiccparam" id="p2egrelease2"
                                 data-midiChannel="2" data-cclsb="24"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2modamt2">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p2modamt2"  
+                            <input
+                                class="midiccparam" id="p2modamt2"
                                 data-midiChannel="2" data-cclsb="30"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2modrate2">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p2modrate2"  
+                            <input
+                                class="midiccparam" id="p2modrate2"
                                 data-midiChannel="2" data-cclsb="47"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
                 <div class="controlitemgroup">
@@ -609,36 +628,43 @@
                     <div>
                         <div class="controller">
                             <label for="p2send">Wave Guide Send</label>
-                            <input 
-                                class="midiccparam" id="p2send"  
+                            <input
+                                class="midiccparam" id="p2send"
                                 data-midiChannel="2" data-cclsb="103"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2bitred">Bit Reduction</label>
-                            <input 
-                                class="midiccparam" id="p2bitred"  
+                            <input
+                                class="midiccparam" id="p2bitred"
                                 data-midiChannel="2" data-cclsb="49"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2fold">Fold</label>
-                            <input 
-                                class="midiccparam" id="p2fold"  
+                            <input
+                                class="midiccparam" id="p2fold"
                                 data-midiChannel="2" data-cclsb="50"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p2drive">Drive</label>
-                            <input 
-                                class="midiccparam" id="p2drive"  
+                            <input
+                                class="midiccparam" id="p2drive"
                                 data-midiChannel="2" data-cclsb="51"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
+                            <label for="p2pan">Pan</label>
+                            <input
+                                class="midiccparam" id="p2pan"
+                                data-midiChannel="2" data-cclsb="10"
+                                max="127" min="0" type="range" />
+                        </div>
+                        <div class="controller">
                             <label for="p2gain">Gain</label>
-                            <input 
-                                class="midiccparam" id="p2gain"  
+                            <input
+                                class="midiccparam" id="p2gain"
                                 data-midiChannel="2" data-cclsb="52"
                                 max="127" min="0" type="range" />
                         </div>
@@ -655,236 +681,242 @@
                 <div class="controlitemgroup">
                     <h3>Layer 1</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                             <label for="p3select1wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part three layer one sine voice"></label>
-                            <input 
+                            <input
                                 type="radio" name="p3select1wave" value="0" checked
                                 class="midicctotal" id="p3select1wavesine"
                                 data-midiChannel="3" data-cclsb="14"/>
-                            
+
                             <label for="p3select1wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part three layer one saw voice"></label>
-                            <input 
-                                type="radio" name="p3select1wave" value="26" 
+                            <input
+                                type="radio" name="p3select1wave" value="26"
                                 class="midicctotal" id="p3select1wavesaw"
                                 data-midiChannel="3" data-cclsb="14"/>
-                            
+
                             <label for="p3select1wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part three layer one high pass noise voice"></label>
-                            <input 
-                                type="radio" name="p3select1wave" value="52" 
+                            <input
+                                type="radio" name="p3select1wave" value="52"
                                 class="midicctotal" id="p3select1wavenoisehp"
                                 data-midiChannel="3" data-cclsb="14"/>
-                            
+
                             <label for="p3select1wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part three layer one low pass noise voice"></label>
-                            <input 
-                                type="radio" name="p3select1wave" value="77" 
+                            <input
+                                type="radio" name="p3select1wave" value="77"
                                 class="midicctotal" id="p3select1wavenoiselp"
                                 data-midiChannel="3" data-cclsb="14"/>
-                            
+
                             <label for="p3select1wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part three layer one band pass noise voice"></label>
-                            <input 
-                                type="radio" name="p3select1wave" value="103" 
+                            <input
+                                type="radio" name="p3select1wave" value="103"
                                 class="midicctotal" id="p3select1wavenoisebp"
                                 data-midiChannel="3" data-cclsb="14"/>
-                            
+
                         </div>
-                        <div class="radiogroup">
+                        <label for="modgroup">Pitch Modulator</label>
+                        <div class="radiogroup" id="modgroup">
                             <label for="p3select1modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part three layer one envelope modulation"></label>
-                            <input 
+                            <input
                                 type="radio" name="p3select1mod" value="0" checked
                                 class="midicctotal" id="p3select1modexp"
                                 data-midiChannel="3" data-cclsb="14"/>
 
                             <label for="p3select1modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part three layer one lfo modulation"></label>
-                            <input 
-                                type="radio" name="p3select1mod" value="9" 
+                            <input
+                                type="radio" name="p3select1mod" value="9"
                                 class="midicctotal" id="p3select1modtri"
                                 data-midiChannel="3" data-cclsb="14"/>
 
                             <label for="p3select1modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part three layer one random modulation"></label>
-                            <input 
-                                type="radio" name="p3select1mod" value="18" 
+                            <input
+                                type="radio" name="p3select1mod" value="18"
                                 class="midicctotal" id="p3select1modrand"
                                 data-midiChannel="3" data-cclsb="14"/>
                         </div>
-                        <div class="radiogroup">
+                        <label for="envgroup">Amplitude Envelope Generator</label>
+                        <div class="radiogroup" id="envgroup">
                             <label for="p3select1envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part three layer one attack delay envelope"></label>
-                            <input 
+                            <input
                                 type="radio" name="p3select1env" value="0" checked
                                 class="midicctotal" id="p3select1envad"
                                 data-midiChannel="3" data-cclsb="14"/>
                             <label for="p3select1envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part three layer one exponential envelope"></label>
-                            <input 
-                                type="radio" name="p3select1env" value="3" 
+                            <input
+                                type="radio" name="p3select1env" value="3"
                                 class="midicctotal" id="p3select1envexp"
                                 data-midiChannel="3" data-cclsb="14"/>
                             <label for="p3select1envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part three layer one multi envelope"></label>
-                            <input 
-                                type="radio" name="p3select1env" value="6" 
+                            <input
+                                type="radio" name="p3select1env" value="6"
                                 class="midicctotal" id="p3select1envmulti"
                                 data-midiChannel="3" data-cclsb="14"/>
                         </div>
                         <div class="controller">
                             <label for="p3level1">Level</label>
-                            <input 
-                                class="midiccparam" id="p3level1"  
+                            <input
+                                class="midiccparam" id="p3level1"
                                 data-midiChannel="3" data-cclsb="17"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p3pitch1">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p3pitch1"  
+                            <input
+                                class="midiccparam" id="p3pitch1"
                                 data-midiChannel="3" data-cclsb="26"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3egattack1">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p3egattack1"  
+                            <input
+                                class="midiccparam" id="p3egattack1"
                                 data-midiChannel="3" data-cclsb="20"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3egrelease1">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p3egrelease1"  
+                            <input
+                                class="midiccparam" id="p3egrelease1"
                                 data-midiChannel="3" data-cclsb="23"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3modamt1">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p3modamt1"  
+                            <input
+                                class="midiccparam" id="p3modamt1"
                                 data-midiChannel="3" data-cclsb="29"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3modrate1">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p3modrate1"  
+                            <input
+                                class="midiccparam" id="p3modrate1"
                                 data-midiChannel="3" data-cclsb="46"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
-            
+
                 <!--Part 3 Layer 2-->
-            
+
                 <div class="controlitemgroup">
                     <h3>Layer 2</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                                 <label for="p3select2wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part three layer one sine voice"></label>
-                                <input 
+                                <input
                                     type="radio" name="p3select2wave" value="0" checked
                                     class="midicctotal" id="p3select2wavesine"
                                     data-midiChannel="3" data-cclsb="15"/>
-                                
+
                                 <label for="p3select2wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part three layer one saw voice"></label>
-                                <input 
-                                    type="radio" name="p3select2wave" value="26" 
+                                <input
+                                    type="radio" name="p3select2wave" value="26"
                                     class="midicctotal" id="p3select2wavesaw"
                                     data-midiChannel="3" data-cclsb="15"/>
-                                
+
                                 <label for="p3select2wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part three layer one high pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p3select2wave" value="52" 
+                                <input
+                                    type="radio" name="p3select2wave" value="52"
                                     class="midicctotal" id="p3select2wavenoisehp"
                                     data-midiChannel="3" data-cclsb="15"/>
-                                
+
                                 <label for="p3select2wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part three layer one low pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p3select2wave" value="77" 
+                                <input
+                                    type="radio" name="p3select2wave" value="77"
                                     class="midicctotal" id="p3select2wavenoiselp"
                                     data-midiChannel="3" data-cclsb="15"/>
-                                
+
                                 <label for="p3select2wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part three layer one band pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p3select2wave" value="103" 
+                                <input
+                                    type="radio" name="p3select2wave" value="103"
                                     class="midicctotal" id="p3select2wavenoisebp"
                                     data-midiChannel="3" data-cclsb="15"/>
-                                
+
                             </div>
-                            <div class="radiogroup">
+                            <label for="modgroup">Pitch Modulator</label>
+                            <div class="radiogroup" id="modgroup">
                                 <label for="p3select2modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part three layer one envelope modulation"></label>
-                                <input 
+                                <input
                                     type="radio" name="p3select2mod" value="0" checked
                                     class="midicctotal" id="p3select2modexp"
                                     data-midiChannel="3" data-cclsb="15"/>
-    
+
                                 <label for="p3select2modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part three layer one lfo modulation"></label>
-                                <input 
-                                    type="radio" name="p3select2mod" value="9" 
+                                <input
+                                    type="radio" name="p3select2mod" value="9"
                                     class="midicctotal" id="p3select2modtri"
                                     data-midiChannel="3" data-cclsb="15"/>
-    
+
                                 <label for="p3select2modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part three layer one random modulation"></label>
-                                <input 
-                                    type="radio" name="p3select2mod" value="18" 
+                                <input
+                                    type="radio" name="p3select2mod" value="18"
                                     class="midicctotal" id="p3select2modrand"
                                     data-midiChannel="3" data-cclsb="15"/>
                             </div>
-                            <div class="radiogroup">
+                            <label for="envgroup">Amplitude Envelope Generator</label>
+                            <div class="radiogroup" id="envgroup">
                                 <label for="p3select2envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part three layer one attack delay envelope"></label>
-                                <input 
+                                <input
                                     type="radio" name="p3select2env" value="0" checked
                                     class="midicctotal" id="p3select2envad"
                                     data-midiChannel="3" data-cclsb="15"/>
                                 <label for="p3select2envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part three layer one exponential envelope"></label>
-                                <input 
-                                    type="radio" name="p3select2env" value="3" 
+                                <input
+                                    type="radio" name="p3select2env" value="3"
                                     class="midicctotal" id="p3select2envexp"
                                     data-midiChannel="3" data-cclsb="15"/>
                                 <label for="p3select2envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part three layer one multi envelope"></label>
-                                <input 
-                                    type="radio" name="p3select2env" value="6" 
+                                <input
+                                    type="radio" name="p3select2env" value="6"
                                     class="midicctotal" id="p3select2envmulti"
                                     data-midiChannel="3" data-cclsb="15"/>
                             </div>
                         <div class="controller">
                             <label for="p3level2">Level</label>
-                            <input 
-                                class="midiccparam" id="p3level2"  
+                            <input
+                                class="midiccparam" id="p3level2"
                                 data-midiChannel="3" data-cclsb="18"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p3pitch2">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p3pitch2"  
+                            <input
+                                class="midiccparam" id="p3pitch2"
                                 data-midiChannel="3" data-cclsb="27"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3egattack2">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p3egattack2"  
+                            <input
+                                class="midiccparam" id="p3egattack2"
                                 data-midiChannel="3" data-cclsb="21"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3egrelease2">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p3egrelease2"  
+                            <input
+                                class="midiccparam" id="p3egrelease2"
                                 data-midiChannel="3" data-cclsb="24"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3modamt2">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p3modamt2"  
+                            <input
+                                class="midiccparam" id="p3modamt2"
                                 data-midiChannel="3" data-cclsb="30"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3modrate2">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p3modrate2"  
+                            <input
+                                class="midiccparam" id="p3modrate2"
                                 data-midiChannel="3" data-cclsb="47"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
                 <div class="controlitemgroup">
@@ -892,36 +924,43 @@
                     <div>
                         <div class="controller">
                             <label for="p3send">Wave Guide Send</label>
-                            <input 
-                                class="midiccparam" id="p3send"  
+                            <input
+                                class="midiccparam" id="p3send"
                                 data-midiChannel="3" data-cclsb="103"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3bitred">Bit Reduction</label>
-                            <input 
-                                class="midiccparam" id="p3bitred"  
+                            <input
+                                class="midiccparam" id="p3bitred"
                                 data-midiChannel="3" data-cclsb="49"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3fold">Fold</label>
-                            <input 
-                                class="midiccparam" id="p3fold"  
+                            <input
+                                class="midiccparam" id="p3fold"
                                 data-midiChannel="3" data-cclsb="50"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p3drive">Drive</label>
-                            <input 
-                                class="midiccparam" id="p3drive"  
+                            <input
+                                class="midiccparam" id="p3drive"
                                 data-midiChannel="3" data-cclsb="51"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
+                            <label for="p3pan">Pan</label>
+                            <input
+                                class="midiccparam" id="p3pan"
+                                data-midiChannel="3" data-cclsb="10"
+                                max="127" min="0" type="range" />
+                        </div>
+                        <div class="controller">
                             <label for="p3gain">Gain</label>
-                            <input 
-                                class="midiccparam" id="p3gain"  
+                            <input
+                                class="midiccparam" id="p3gain"
                                 data-midiChannel="3" data-cclsb="52"
                                 max="127" min="0" type="range" />
                         </div>
@@ -938,236 +977,242 @@
                 <div class="controlitemgroup">
                     <h3>Layer 1</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                             <label for="p4select1wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part four layer one sine voice"></label>
-                            <input 
+                            <input
                                 type="radio" name="p4select1wave" value="0" checked
                                 class="midicctotal" id="p4select1wavesine"
                                 data-midiChannel="4" data-cclsb="14"/>
-                            
+
                             <label for="p4select1wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part four layer one saw voice"></label>
-                            <input 
-                                type="radio" name="p4select1wave" value="26" 
+                            <input
+                                type="radio" name="p4select1wave" value="26"
                                 class="midicctotal" id="p4select1wavesaw"
                                 data-midiChannel="4" data-cclsb="14"/>
-                            
+
                             <label for="p4select1wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part four layer one high pass noise voice"></label>
-                            <input 
-                                type="radio" name="p4select1wave" value="52" 
+                            <input
+                                type="radio" name="p4select1wave" value="52"
                                 class="midicctotal" id="p4select1wavenoisehp"
                                 data-midiChannel="4" data-cclsb="14"/>
-                            
+
                             <label for="p4select1wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part four layer one low pass noise voice"></label>
-                            <input 
-                                type="radio" name="p4select1wave" value="77" 
+                            <input
+                                type="radio" name="p4select1wave" value="77"
                                 class="midicctotal" id="p4select1wavenoiselp"
                                 data-midiChannel="4" data-cclsb="14"/>
-                            
+
                             <label for="p4select1wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part four layer one band pass noise voice"></label>
-                            <input 
-                                type="radio" name="p4select1wave" value="103" 
+                            <input
+                                type="radio" name="p4select1wave" value="103"
                                 class="midicctotal" id="p4select1wavenoisebp"
                                 data-midiChannel="4" data-cclsb="14"/>
-                            
+
                         </div>
-                        <div class="radiogroup">
+                        <label for="modgroup">Pitch Modulator</label>
+                        <div class="radiogroup" id="modgroup">
                             <label for="p4select1modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part four layer one envelope modulation"></label>
-                            <input 
+                            <input
                                 type="radio" name="p4select1mod" value="0" checked
                                 class="midicctotal" id="p4select1modexp"
                                 data-midiChannel="4" data-cclsb="14"/>
 
                             <label for="p4select1modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part four layer one lfo modulation"></label>
-                            <input 
-                                type="radio" name="p4select1mod" value="9" 
+                            <input
+                                type="radio" name="p4select1mod" value="9"
                                 class="midicctotal" id="p4select1modtri"
                                 data-midiChannel="4" data-cclsb="14"/>
 
                             <label for="p4select1modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part four layer one random modulation"></label>
-                            <input 
-                                type="radio" name="p4select1mod" value="18" 
+                            <input
+                                type="radio" name="p4select1mod" value="18"
                                 class="midicctotal" id="p4select1modrand"
                                 data-midiChannel="4" data-cclsb="14"/>
                         </div>
-                        <div class="radiogroup">
+                        <label for="envgroup">Amplitude Envelope Generator</label>
+                        <div class="radiogroup" id="envgroup">
                             <label for="p4select1envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part four layer one attack delay envelope"></label>
-                            <input 
+                            <input
                                 type="radio" name="p4select1env" value="0" checked
                                 class="midicctotal" id="p4select1envad"
                                 data-midiChannel="4" data-cclsb="14"/>
                             <label for="p4select1envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part four layer one exponential envelope"></label>
-                            <input 
-                                type="radio" name="p4select1env" value="3" 
+                            <input
+                                type="radio" name="p4select1env" value="3"
                                 class="midicctotal" id="p4select1envexp"
                                 data-midiChannel="4" data-cclsb="14"/>
                             <label for="p4select1envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part four layer one multi envelope"></label>
-                            <input 
-                                type="radio" name="p4select1env" value="6" 
+                            <input
+                                type="radio" name="p4select1env" value="6"
                                 class="midicctotal" id="p4select1envmulti"
                                 data-midiChannel="4" data-cclsb="14"/>
                         </div>
                         <div class="controller">
                             <label for="p4level1">Level</label>
-                            <input 
-                                class="midiccparam" id="p4level1"  
+                            <input
+                                class="midiccparam" id="p4level1"
                                 data-midiChannel="4" data-cclsb="17"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p4pitch1">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p4pitch1"  
+                            <input
+                                class="midiccparam" id="p4pitch1"
                                 data-midiChannel="4" data-cclsb="26"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4egattack1">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p4egattack1"  
+                            <input
+                                class="midiccparam" id="p4egattack1"
                                 data-midiChannel="4" data-cclsb="20"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4egrelease1">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p4egrelease1"  
+                            <input
+                                class="midiccparam" id="p4egrelease1"
                                 data-midiChannel="4" data-cclsb="23"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4modamt1">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p4modamt1"  
+                            <input
+                                class="midiccparam" id="p4modamt1"
                                 data-midiChannel="4" data-cclsb="29"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4modrate1">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p4modrate1"  
+                            <input
+                                class="midiccparam" id="p4modrate1"
                                 data-midiChannel="4" data-cclsb="46"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
-            
+
                 <!--Part 4 Layer 2-->
-            
+
                 <div class="controlitemgroup">
                     <h3>Layer 2</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                                 <label for="p4select2wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part four layer one sine voice"></label>
-                                <input 
+                                <input
                                     type="radio" name="p4select2wave" value="0" checked
                                     class="midicctotal" id="p4select2wavesine"
                                     data-midiChannel="4" data-cclsb="15"/>
-                                
+
                                 <label for="p4select2wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part four layer one saw voice"></label>
-                                <input 
-                                    type="radio" name="p4select2wave" value="26" 
+                                <input
+                                    type="radio" name="p4select2wave" value="26"
                                     class="midicctotal" id="p4select2wavesaw"
                                     data-midiChannel="4" data-cclsb="15"/>
-                                
+
                                 <label for="p4select2wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part four layer one high pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p4select2wave" value="52" 
+                                <input
+                                    type="radio" name="p4select2wave" value="52"
                                     class="midicctotal" id="p4select2wavenoisehp"
                                     data-midiChannel="4" data-cclsb="15"/>
-                                
+
                                 <label for="p4select2wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part four layer one low pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p4select2wave" value="77" 
+                                <input
+                                    type="radio" name="p4select2wave" value="77"
                                     class="midicctotal" id="p4select2wavenoiselp"
                                     data-midiChannel="4" data-cclsb="15"/>
-                                
+
                                 <label for="p4select2wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part four layer one band pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p4select2wave" value="103" 
+                                <input
+                                    type="radio" name="p4select2wave" value="103"
                                     class="midicctotal" id="p4select2wavenoisebp"
                                     data-midiChannel="4" data-cclsb="15"/>
-                                
+
                             </div>
-                            <div class="radiogroup">
+                            <label for="modgroup">Pitch Modulator</label>
+                            <div class="radiogroup" id="modgroup">
                                 <label for="p4select2modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part four layer one envelope modulation"></label>
-                                <input 
+                                <input
                                     type="radio" name="p4select2mod" value="0" checked
                                     class="midicctotal" id="p4select2modexp"
                                     data-midiChannel="4" data-cclsb="15"/>
-    
+
                                 <label for="p4select2modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part four layer one lfo modulation"></label>
-                                <input 
-                                    type="radio" name="p4select2mod" value="9" 
+                                <input
+                                    type="radio" name="p4select2mod" value="9"
                                     class="midicctotal" id="p4select2modtri"
                                     data-midiChannel="4" data-cclsb="15"/>
-    
+
                                 <label for="p4select2modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part four layer one random modulation"></label>
-                                <input 
-                                    type="radio" name="p4select2mod" value="18" 
+                                <input
+                                    type="radio" name="p4select2mod" value="18"
                                     class="midicctotal" id="p4select2modrand"
                                     data-midiChannel="4" data-cclsb="15"/>
                             </div>
-                            <div class="radiogroup">
+                            <label for="envgroup">Amplitude Envelope Generator</label>
+                            <div class="radiogroup" id="envgroup">
                                 <label for="p4select2envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part four layer one attack delay envelope"></label>
-                                <input 
+                                <input
                                     type="radio" name="p4select2env" value="0" checked
                                     class="midicctotal" id="p4select2envad"
                                     data-midiChannel="4" data-cclsb="15"/>
                                 <label for="p4select2envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part four layer one exponential envelope"></label>
-                                <input 
-                                    type="radio" name="p4select2env" value="3" 
+                                <input
+                                    type="radio" name="p4select2env" value="3"
                                     class="midicctotal" id="p4select2envexp"
                                     data-midiChannel="4" data-cclsb="15"/>
                                 <label for="p4select2envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part four layer one multi envelope"></label>
-                                <input 
-                                    type="radio" name="p4select2env" value="6" 
+                                <input
+                                    type="radio" name="p4select2env" value="6"
                                     class="midicctotal" id="p4select2envmulti"
                                     data-midiChannel="4" data-cclsb="15"/>
                             </div>
                         <div class="controller">
                             <label for="p4level2">Level</label>
-                            <input 
-                                class="midiccparam" id="p4level2"  
+                            <input
+                                class="midiccparam" id="p4level2"
                                 data-midiChannel="4" data-cclsb="18"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p4pitch2">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p4pitch2"  
+                            <input
+                                class="midiccparam" id="p4pitch2"
                                 data-midiChannel="4" data-cclsb="27"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4egattack2">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p4egattack2"  
+                            <input
+                                class="midiccparam" id="p4egattack2"
                                 data-midiChannel="4" data-cclsb="21"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4egrelease2">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p4egrelease2"  
+                            <input
+                                class="midiccparam" id="p4egrelease2"
                                 data-midiChannel="4" data-cclsb="24"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4modamt2">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p4modamt2"  
+                            <input
+                                class="midiccparam" id="p4modamt2"
                                 data-midiChannel="4" data-cclsb="30"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4modrate2">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p4modrate2"  
+                            <input
+                                class="midiccparam" id="p4modrate2"
                                 data-midiChannel="4" data-cclsb="47"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
                 <div class="controlitemgroup">
@@ -1175,36 +1220,43 @@
                     <div>
                         <div class="controller">
                             <label for="p4send">Wave Guide Send</label>
-                            <input 
-                                class="midiccparam" id="p4send"  
+                            <input
+                                class="midiccparam" id="p4send"
                                 data-midiChannel="4" data-cclsb="103"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4bitred">Bit Reduction</label>
-                            <input 
-                                class="midiccparam" id="p4bitred"  
+                            <input
+                                class="midiccparam" id="p4bitred"
                                 data-midiChannel="4" data-cclsb="49"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4fold">Fold</label>
-                            <input 
-                                class="midiccparam" id="p4fold"  
+                            <input
+                                class="midiccparam" id="p4fold"
                                 data-midiChannel="4" data-cclsb="50"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p4drive">Drive</label>
-                            <input 
-                                class="midiccparam" id="p4drive"  
+                            <input
+                                class="midiccparam" id="p4drive"
                                 data-midiChannel="4" data-cclsb="51"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
+                            <label for="p4pan">Pan</label>
+                            <input
+                                class="midiccparam" id="p4pan"
+                                data-midiChannel="4" data-cclsb="10"
+                                max="127" min="0" type="range" />
+                        </div>
+                        <div class="controller">
                             <label for="p4gain">Gain</label>
-                            <input 
-                                class="midiccparam" id="p4gain"  
+                            <input
+                                class="midiccparam" id="p4gain"
                                 data-midiChannel="4" data-cclsb="52"
                                 max="127" min="0" type="range" />
                         </div>
@@ -1221,236 +1273,242 @@
                 <div class="controlitemgroup">
                     <h3>Layer 1</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                             <label for="p5select1wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part five layer one sine voice"></label>
-                            <input 
+                            <input
                                 type="radio" name="p5select1wave" value="0" checked
                                 class="midicctotal" id="p5select1wavesine"
                                 data-midiChannel="5" data-cclsb="14"/>
-                            
+
                             <label for="p5select1wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part five layer one saw voice"></label>
-                            <input 
-                                type="radio" name="p5select1wave" value="26" 
+                            <input
+                                type="radio" name="p5select1wave" value="26"
                                 class="midicctotal" id="p5select1wavesaw"
                                 data-midiChannel="5" data-cclsb="14"/>
-                            
+
                             <label for="p5select1wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part five layer one high pass noise voice"></label>
-                            <input 
-                                type="radio" name="p5select1wave" value="52" 
+                            <input
+                                type="radio" name="p5select1wave" value="52"
                                 class="midicctotal" id="p5select1wavenoisehp"
                                 data-midiChannel="5" data-cclsb="14"/>
-                            
+
                             <label for="p5select1wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part five layer one low pass noise voice"></label>
-                            <input 
-                                type="radio" name="p5select1wave" value="77" 
+                            <input
+                                type="radio" name="p5select1wave" value="77"
                                 class="midicctotal" id="p5select1wavenoiselp"
                                 data-midiChannel="5" data-cclsb="14"/>
-                            
+
                             <label for="p5select1wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part five layer one band pass noise voice"></label>
-                            <input 
-                                type="radio" name="p5select1wave" value="103" 
+                            <input
+                                type="radio" name="p5select1wave" value="103"
                                 class="midicctotal" id="p5select1wavenoisebp"
                                 data-midiChannel="5" data-cclsb="14"/>
-                            
+
                         </div>
-                        <div class="radiogroup">
+                        <label for="modgroup">Pitch Modulator</label>
+                        <div class="radiogroup" id="modgroup">
                             <label for="p5select1modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part five layer one envelope modulation"></label>
-                            <input 
+                            <input
                                 type="radio" name="p5select1mod" value="0" checked
                                 class="midicctotal" id="p5select1modexp"
                                 data-midiChannel="5" data-cclsb="14"/>
 
                             <label for="p5select1modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part five layer one lfo modulation"></label>
-                            <input 
-                                type="radio" name="p5select1mod" value="9" 
+                            <input
+                                type="radio" name="p5select1mod" value="9"
                                 class="midicctotal" id="p5select1modtri"
                                 data-midiChannel="5" data-cclsb="14"/>
 
                             <label for="p5select1modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part five layer one random modulation"></label>
-                            <input 
-                                type="radio" name="p5select1mod" value="18" 
+                            <input
+                                type="radio" name="p5select1mod" value="18"
                                 class="midicctotal" id="p5select1modrand"
                                 data-midiChannel="5" data-cclsb="14"/>
                         </div>
-                        <div class="radiogroup">
+                        <label for="envgroup">Amplitude Envelope Generator</label>
+                        <div class="radiogroup" id="envgroup">
                             <label for="p5select1envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part five layer one attack delay envelope"></label>
-                            <input 
+                            <input
                                 type="radio" name="p5select1env" value="0" checked
                                 class="midicctotal" id="p5select1envad"
                                 data-midiChannel="5" data-cclsb="14"/>
                             <label for="p5select1envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part five layer one exponential envelope"></label>
-                            <input 
-                                type="radio" name="p5select1env" value="3" 
+                            <input
+                                type="radio" name="p5select1env" value="3"
                                 class="midicctotal" id="p5select1envexp"
                                 data-midiChannel="5" data-cclsb="14"/>
                             <label for="p5select1envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part five layer one multi envelope"></label>
-                            <input 
-                                type="radio" name="p5select1env" value="6" 
+                            <input
+                                type="radio" name="p5select1env" value="6"
                                 class="midicctotal" id="p5select1envmulti"
                                 data-midiChannel="5" data-cclsb="14"/>
                         </div>
                         <div class="controller">
                             <label for="p5level1">Level</label>
-                            <input 
-                                class="midiccparam" id="p5level1"  
+                            <input
+                                class="midiccparam" id="p5level1"
                                 data-midiChannel="5" data-cclsb="17"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p5pitch1">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p5pitch1"  
+                            <input
+                                class="midiccparam" id="p5pitch1"
                                 data-midiChannel="5" data-cclsb="26"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5egattack1">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p5egattack1"  
+                            <input
+                                class="midiccparam" id="p5egattack1"
                                 data-midiChannel="5" data-cclsb="20"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5egrelease1">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p5egrelease1"  
+                            <input
+                                class="midiccparam" id="p5egrelease1"
                                 data-midiChannel="5" data-cclsb="23"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5modamt1">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p5modamt1"  
+                            <input
+                                class="midiccparam" id="p5modamt1"
                                 data-midiChannel="5" data-cclsb="29"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5modrate1">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p5modrate1"  
+                            <input
+                                class="midiccparam" id="p5modrate1"
                                 data-midiChannel="5" data-cclsb="46"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
-            
+
                 <!--Part 5 Layer 2-->
-            
+
                 <div class="controlitemgroup">
                     <h3>Layer 2</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                                 <label for="p5select2wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part five layer one sine voice"></label>
-                                <input 
+                                <input
                                     type="radio" name="p5select2wave" value="0" checked
                                     class="midicctotal" id="p5select2wavesine"
                                     data-midiChannel="5" data-cclsb="15"/>
-                                
+
                                 <label for="p5select2wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part five layer one saw voice"></label>
-                                <input 
-                                    type="radio" name="p5select2wave" value="26" 
+                                <input
+                                    type="radio" name="p5select2wave" value="26"
                                     class="midicctotal" id="p5select2wavesaw"
                                     data-midiChannel="5" data-cclsb="15"/>
-                                
+
                                 <label for="p5select2wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part five layer one high pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p5select2wave" value="52" 
+                                <input
+                                    type="radio" name="p5select2wave" value="52"
                                     class="midicctotal" id="p5select2wavenoisehp"
                                     data-midiChannel="5" data-cclsb="15"/>
-                                
+
                                 <label for="p5select2wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part five layer one low pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p5select2wave" value="77" 
+                                <input
+                                    type="radio" name="p5select2wave" value="77"
                                     class="midicctotal" id="p5select2wavenoiselp"
                                     data-midiChannel="5" data-cclsb="15"/>
-                                
+
                                 <label for="p5select2wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part five layer one band pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p5select2wave" value="103" 
+                                <input
+                                    type="radio" name="p5select2wave" value="103"
                                     class="midicctotal" id="p5select2wavenoisebp"
                                     data-midiChannel="5" data-cclsb="15"/>
-                                
+
                             </div>
-                            <div class="radiogroup">
+                            <label for="modgroup">Pitch Modulator</label>
+                            <div class="radiogroup" id="modgroup">
                                 <label for="p5select2modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part five layer one envelope modulation"></label>
-                                <input 
+                                <input
                                     type="radio" name="p5select2mod" value="0" checked
                                     class="midicctotal" id="p5select2modexp"
                                     data-midiChannel="5" data-cclsb="15"/>
-    
+
                                 <label for="p5select2modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part five layer one lfo modulation"></label>
-                                <input 
-                                    type="radio" name="p5select2mod" value="9" 
+                                <input
+                                    type="radio" name="p5select2mod" value="9"
                                     class="midicctotal" id="p5select2modtri"
                                     data-midiChannel="5" data-cclsb="15"/>
-    
+
                                 <label for="p5select2modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part five layer one random modulation"></label>
-                                <input 
-                                    type="radio" name="p5select2mod" value="18" 
+                                <input
+                                    type="radio" name="p5select2mod" value="18"
                                     class="midicctotal" id="p5select2modrand"
                                     data-midiChannel="5" data-cclsb="15"/>
                             </div>
-                            <div class="radiogroup">
+                            <label for="envgroup">Amplitude Envelope Generator</label>
+                            <div class="radiogroup" id="envgroup">
                                 <label for="p5select2envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part five layer one attack delay envelope"></label>
-                                <input 
+                                <input
                                     type="radio" name="p5select2env" value="0" checked
                                     class="midicctotal" id="p5select2envad"
                                     data-midiChannel="5" data-cclsb="15"/>
                                 <label for="p5select2envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part five layer one exponential envelope"></label>
-                                <input 
-                                    type="radio" name="p5select2env" value="3" 
+                                <input
+                                    type="radio" name="p5select2env" value="3"
                                     class="midicctotal" id="p5select2envexp"
                                     data-midiChannel="5" data-cclsb="15"/>
                                 <label for="p5select2envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part five layer one multi envelope"></label>
-                                <input 
-                                    type="radio" name="p5select2env" value="6" 
+                                <input
+                                    type="radio" name="p5select2env" value="6"
                                     class="midicctotal" id="p5select2envmulti"
                                     data-midiChannel="5" data-cclsb="15"/>
                             </div>
                         <div class="controller">
                             <label for="p5level2">Level</label>
-                            <input 
-                                class="midiccparam" id="p5level2"  
+                            <input
+                                class="midiccparam" id="p5level2"
                                 data-midiChannel="5" data-cclsb="18"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p5pitch2">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p5pitch2"  
+                            <input
+                                class="midiccparam" id="p5pitch2"
                                 data-midiChannel="5" data-cclsb="27"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5egattack2">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p5egattack2"  
+                            <input
+                                class="midiccparam" id="p5egattack2"
                                 data-midiChannel="5" data-cclsb="21"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5egrelease2">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p5egrelease2"  
+                            <input
+                                class="midiccparam" id="p5egrelease2"
                                 data-midiChannel="5" data-cclsb="24"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5modamt2">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p5modamt2"  
+                            <input
+                                class="midiccparam" id="p5modamt2"
                                 data-midiChannel="5" data-cclsb="30"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5modrate2">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p5modrate2"  
+                            <input
+                                class="midiccparam" id="p5modrate2"
                                 data-midiChannel="5" data-cclsb="47"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
                 <div class="controlitemgroup">
@@ -1458,36 +1516,43 @@
                     <div>
                         <div class="controller">
                             <label for="p5send">Wave Guide Send</label>
-                            <input 
-                                class="midiccparam" id="p5send"  
+                            <input
+                                class="midiccparam" id="p5send"
                                 data-midiChannel="5" data-cclsb="103"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5bitred">Bit Reduction</label>
-                            <input 
-                                class="midiccparam" id="p5bitred"  
+                            <input
+                                class="midiccparam" id="p5bitred"
                                 data-midiChannel="5" data-cclsb="49"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5fold">Fold</label>
-                            <input 
-                                class="midiccparam" id="p5fold"  
+                            <input
+                                class="midiccparam" id="p5fold"
                                 data-midiChannel="5" data-cclsb="50"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p5drive">Drive</label>
-                            <input 
-                                class="midiccparam" id="p5drive"  
+                            <input
+                                class="midiccparam" id="p5drive"
                                 data-midiChannel="5" data-cclsb="51"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
+                            <label for="p5pan">Pan</label>
+                            <input
+                                class="midiccparam" id="p5pan"
+                                data-midiChannel="5" data-cclsb="10"
+                                max="127" min="0" type="range" />
+                        </div>
+                        <div class="controller">
                             <label for="p5gain">Gain</label>
-                            <input 
-                                class="midiccparam" id="p5gain"  
+                            <input
+                                class="midiccparam" id="p5gain"
                                 data-midiChannel="5" data-cclsb="52"
                                 max="127" min="0" type="range" />
                         </div>
@@ -1504,236 +1569,242 @@
                 <div class="controlitemgroup">
                     <h3>Layer 1</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                             <label for="p6select1wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part six layer one sine voice"></label>
-                            <input 
+                            <input
                                 type="radio" name="p6select1wave" value="0" checked
                                 class="midicctotal" id="p6select1wavesine"
                                 data-midiChannel="6" data-cclsb="14"/>
-                            
+
                             <label for="p6select1wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part six layer one saw voice"></label>
-                            <input 
-                                type="radio" name="p6select1wave" value="26" 
+                            <input
+                                type="radio" name="p6select1wave" value="26"
                                 class="midicctotal" id="p6select1wavesaw"
                                 data-midiChannel="6" data-cclsb="14"/>
-                            
+
                             <label for="p6select1wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part six layer one high pass noise voice"></label>
-                            <input 
-                                type="radio" name="p6select1wave" value="52" 
+                            <input
+                                type="radio" name="p6select1wave" value="52"
                                 class="midicctotal" id="p6select1wavenoisehp"
                                 data-midiChannel="6" data-cclsb="14"/>
-                            
+
                             <label for="p6select1wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part six layer one low pass noise voice"></label>
-                            <input 
-                                type="radio" name="p6select1wave" value="77" 
+                            <input
+                                type="radio" name="p6select1wave" value="77"
                                 class="midicctotal" id="p6select1wavenoiselp"
                                 data-midiChannel="6" data-cclsb="14"/>
-                            
+
                             <label for="p6select1wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part six layer one band pass noise voice"></label>
-                            <input 
-                                type="radio" name="p6select1wave" value="103" 
+                            <input
+                                type="radio" name="p6select1wave" value="103"
                                 class="midicctotal" id="p6select1wavenoisebp"
                                 data-midiChannel="6" data-cclsb="14"/>
-                            
+
                         </div>
-                        <div class="radiogroup">
+                        <label for="modgroup">Pitch Modulator</label>
+                        <div class="radiogroup" id="modgroup">
                             <label for="p6select1modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part six layer one envelope modulation"></label>
-                            <input 
+                            <input
                                 type="radio" name="p6select1mod" value="0" checked
                                 class="midicctotal" id="p6select1modexp"
                                 data-midiChannel="6" data-cclsb="14"/>
 
                             <label for="p6select1modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part six layer one lfo modulation"></label>
-                            <input 
-                                type="radio" name="p6select1mod" value="9" 
+                            <input
+                                type="radio" name="p6select1mod" value="9"
                                 class="midicctotal" id="p6select1modtri"
                                 data-midiChannel="6" data-cclsb="14"/>
 
                             <label for="p6select1modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part six layer one random modulation"></label>
-                            <input 
-                                type="radio" name="p6select1mod" value="18" 
+                            <input
+                                type="radio" name="p6select1mod" value="18"
                                 class="midicctotal" id="p6select1modrand"
                                 data-midiChannel="6" data-cclsb="14"/>
                         </div>
-                        <div class="radiogroup">
+                        <label for="envgroup">Amplitude Envelope Generator</label>
+                        <div class="radiogroup" id="envgroup">
                             <label for="p6select1envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part six layer one attack delay envelope"></label>
-                            <input 
+                            <input
                                 type="radio" name="p6select1env" value="0" checked
                                 class="midicctotal" id="p6select1envad"
                                 data-midiChannel="6" data-cclsb="14"/>
                             <label for="p6select1envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part six layer one exponential envelope"></label>
-                            <input 
-                                type="radio" name="p6select1env" value="3" 
+                            <input
+                                type="radio" name="p6select1env" value="3"
                                 class="midicctotal" id="p6select1envexp"
                                 data-midiChannel="6" data-cclsb="14"/>
                             <label for="p6select1envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part six layer one multi envelope"></label>
-                            <input 
-                                type="radio" name="p6select1env" value="6" 
+                            <input
+                                type="radio" name="p6select1env" value="6"
                                 class="midicctotal" id="p6select1envmulti"
                                 data-midiChannel="6" data-cclsb="14"/>
                         </div>
                         <div class="controller">
                             <label for="p6level1">Level</label>
-                            <input 
-                                class="midiccparam" id="p6level1"  
+                            <input
+                                class="midiccparam" id="p6level1"
                                 data-midiChannel="6" data-cclsb="17"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p6pitch1">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p6pitch1"  
+                            <input
+                                class="midiccparam" id="p6pitch1"
                                 data-midiChannel="6" data-cclsb="26"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6egattack1">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p6egattack1"  
+                            <input
+                                class="midiccparam" id="p6egattack1"
                                 data-midiChannel="6" data-cclsb="20"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6egrelease1">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p6egrelease1"  
+                            <input
+                                class="midiccparam" id="p6egrelease1"
                                 data-midiChannel="6" data-cclsb="23"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6modamt1">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p6modamt1"  
+                            <input
+                                class="midiccparam" id="p6modamt1"
                                 data-midiChannel="6" data-cclsb="29"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6modrate1">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p6modrate1"  
+                            <input
+                                class="midiccparam" id="p6modrate1"
                                 data-midiChannel="6" data-cclsb="46"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
-            
+
                 <!--Part 6 Layer 2-->
-            
+
                 <div class="controlitemgroup">
                     <h3>Layer 2</h3>
                     <div>
-                        <div class="radiogroup">
+                        <label for="wavegroup">Sound Source</label>
+                        <div class="radiogroup" id="wavegroup">
                                 <label for="p6select2wavesine" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part six layer one sine voice"></label>
-                                <input 
+                                <input
                                     type="radio" name="p6select2wave" value="0" checked
                                     class="midicctotal" id="p6select2wavesine"
                                     data-midiChannel="6" data-cclsb="15"/>
-                                
+
                                 <label for="p6select2wavesaw" class="lcdlabel"><img src="./img/lcd/vdrum-saw.png" alt="part six layer one saw voice"></label>
-                                <input 
-                                    type="radio" name="p6select2wave" value="26" 
+                                <input
+                                    type="radio" name="p6select2wave" value="26"
                                     class="midicctotal" id="p6select2wavesaw"
                                     data-midiChannel="6" data-cclsb="15"/>
-                                
+
                                 <label for="p6select2wavenoisehp" class="lcdlabel"><img src="./img/lcd/vdrum-hp.png" alt="part six layer one high pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p6select2wave" value="52" 
+                                <input
+                                    type="radio" name="p6select2wave" value="52"
                                     class="midicctotal" id="p6select2wavenoisehp"
                                     data-midiChannel="6" data-cclsb="15"/>
-                                
+
                                 <label for="p6select2wavenoiselp" class="lcdlabel"><img src="./img/lcd/vdrum-lp.png" alt="part six layer one low pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p6select2wave" value="77" 
+                                <input
+                                    type="radio" name="p6select2wave" value="77"
                                     class="midicctotal" id="p6select2wavenoiselp"
                                     data-midiChannel="6" data-cclsb="15"/>
-                                
+
                                 <label for="p6select2wavenoisebp" class="lcdlabel"><img src="./img/lcd/vdrum-bp.png" alt="part six layer one band pass noise voice"></label>
-                                <input 
-                                    type="radio" name="p6select2wave" value="103" 
+                                <input
+                                    type="radio" name="p6select2wave" value="103"
                                     class="midicctotal" id="p6select2wavenoisebp"
                                     data-midiChannel="6" data-cclsb="15"/>
-                                
+
                             </div>
-                            <div class="radiogroup">
+                            <label for="modgroup">Pitch Modulator</label>
+                            <div class="radiogroup" id="modgroup">
                                 <label for="p6select2modexp" class="lcdlabel"><img src="./img/lcd/vdrum-admod.png" alt="part six layer one envelope modulation"></label>
-                                <input 
+                                <input
                                     type="radio" name="p6select2mod" value="0" checked
                                     class="midicctotal" id="p6select2modexp"
                                     data-midiChannel="6" data-cclsb="15"/>
-    
+
                                 <label for="p6select2modtri" class="lcdlabel"><img src="./img/lcd/vdrum-sine.png" alt="part six layer one lfo modulation"></label>
-                                <input 
-                                    type="radio" name="p6select2mod" value="9" 
+                                <input
+                                    type="radio" name="p6select2mod" value="9"
                                     class="midicctotal" id="p6select2modtri"
                                     data-midiChannel="6" data-cclsb="15"/>
-    
+
                                 <label for="p6select2modrand" class="lcdlabel"><img src="./img/lcd/vdrum-noisemod.png" alt="part six layer one random modulation"></label>
-                                <input 
-                                    type="radio" name="p6select2mod" value="18" 
+                                <input
+                                    type="radio" name="p6select2mod" value="18"
                                     class="midicctotal" id="p6select2modrand"
                                     data-midiChannel="6" data-cclsb="15"/>
                             </div>
-                            <div class="radiogroup">
+                            <label for="envgroup">Amplitude Envelope Generator</label>
+                            <div class="radiogroup" id="envgroup">
                                 <label for="p6select2envad" class="lcdlabel"><img src="./img/lcd/vdrum-adenv.png" alt="part six layer one attack delay envelope"></label>
-                                <input 
+                                <input
                                     type="radio" name="p6select2env" value="0" checked
                                     class="midicctotal" id="p6select2envad"
                                     data-midiChannel="6" data-cclsb="15"/>
                                 <label for="p6select2envexp" class="lcdlabel"><img src="./img/lcd/vdrum-expenv.png" alt="part six layer one exponential envelope"></label>
-                                <input 
-                                    type="radio" name="p6select2env" value="3" 
+                                <input
+                                    type="radio" name="p6select2env" value="3"
                                     class="midicctotal" id="p6select2envexp"
                                     data-midiChannel="6" data-cclsb="15"/>
                                 <label for="p6select2envmulti" class="lcdlabel"><img src="./img/lcd/vdrum-multienv.png" alt="part six layer one multi envelope"></label>
-                                <input 
-                                    type="radio" name="p6select2env" value="6" 
+                                <input
+                                    type="radio" name="p6select2env" value="6"
                                     class="midicctotal" id="p6select2envmulti"
                                     data-midiChannel="6" data-cclsb="15"/>
                             </div>
                         <div class="controller">
                             <label for="p6level2">Level</label>
-                            <input 
-                                class="midiccparam" id="p6level2"  
+                            <input
+                                class="midiccparam" id="p6level2"
                                 data-midiChannel="6" data-cclsb="18"
                                 max="127" min="0" type="range" >
                         </div>
                         <div class="controller">
                             <label for="p6pitch2">Pitch</label>
-                            <input 
-                                class="midiccparam" id="p6pitch2"  
+                            <input
+                                class="midiccparam" id="p6pitch2"
                                 data-midiChannel="6" data-cclsb="27"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6egattack2">EG Attack</label>
-                            <input 
-                                class="midiccparam" id="p6egattack2"  
+                            <input
+                                class="midiccparam" id="p6egattack2"
                                 data-midiChannel="6" data-cclsb="21"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6egrelease2">EG Release</label>
-                            <input 
-                                class="midiccparam" id="p6egrelease2"  
+                            <input
+                                class="midiccparam" id="p6egrelease2"
                                 data-midiChannel="6" data-cclsb="24"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6modamt2">Mod Amount</label>
-                            <input 
-                                class="midiccparam" id="p6modamt2"  
+                            <input
+                                class="midiccparam" id="p6modamt2"
                                 data-midiChannel="6" data-cclsb="30"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6modrate2">Mod Rate</label>
-                            <input 
-                                class="midiccparam" id="p6modrate2"  
+                            <input
+                                class="midiccparam" id="p6modrate2"
                                 data-midiChannel="6" data-cclsb="47"
                                 max="127" min="0" type="range" />
                         </div>
-                        
+
                     </div>
                 </div>
                 <div class="controlitemgroup">
@@ -1741,36 +1812,43 @@
                     <div>
                         <div class="controller">
                             <label for="p6send">Wave Guide Send</label>
-                            <input 
-                                class="midiccparam" id="p6send"  
+                            <input
+                                class="midiccparam" id="p6send"
                                 data-midiChannel="6" data-cclsb="103"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6bitred">Bit Reduction</label>
-                            <input 
-                                class="midiccparam" id="p6bitred"  
+                            <input
+                                class="midiccparam" id="p6bitred"
                                 data-midiChannel="6" data-cclsb="49"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6fold">Fold</label>
-                            <input 
-                                class="midiccparam" id="p6fold"  
+                            <input
+                                class="midiccparam" id="p6fold"
                                 data-midiChannel="6" data-cclsb="50"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
                             <label for="p6drive">Drive</label>
-                            <input 
-                                class="midiccparam" id="p6drive"  
+                            <input
+                                class="midiccparam" id="p6drive"
                                 data-midiChannel="6" data-cclsb="51"
                                 max="127" min="0" type="range" />
                         </div>
                         <div class="controller">
+                            <label for="p6pan">Pan</label>
+                            <input
+                                class="midiccparam" id="p6pan"
+                                data-midiChannel="6" data-cclsb="10"
+                                max="127" min="0" type="range" />
+                        </div>
+                        <div class="controller">
                             <label for="p6gain">Gain</label>
-                            <input 
-                                class="midiccparam" id="p6gain"  
+                            <input
+                                class="midiccparam" id="p6gain"
                                 data-midiChannel="6" data-cclsb="52"
                                 max="127" min="0" type="range" />
                         </div>
@@ -1787,35 +1865,35 @@
                     <div class="radiogroup">
                         <span>Model Type: </span>
                         <label for="wgmodeltube">Tube</label>
-                        <input 
+                        <input
                             type="radio" name="wgModelType" value="0" checked
                             class="midicctotal" id="wgmodeltube"
                             data-midiChannel="1" data-cclsb="116"/>
-                        
+
                         <label for="wgmodelspring">Spring</label>
-                        <input 
-                            type="radio" name="wgModelType" value="64" 
+                        <input
+                            type="radio" name="wgModelType" value="64"
                             class="midicctotal" id="wgmodelspring"
                             data-midiChannel="1" data-cclsb="116"/>
                     </div>
                     <div class="controller">
                         <label for="wgdecay">Decay</label>
-                        <input 
-                            class="midiccparam" id="wgdecay"  
+                        <input
+                            class="midiccparam" id="wgdecay"
                             data-midiChannel="1" data-cclsb="117"
                             max="127" min="0" type="range" />
                     </div>
                     <div class="controller">
                         <label for="wgbody">Body</label>
-                        <input 
-                            class="midiccparam" id="wgbody"  
+                        <input
+                            class="midiccparam" id="wgbody"
                             data-midiChannel="1" data-cclsb="118"
                             max="127" min="0" type="range" />
                     </div>
                     <div class="controller">
                         <label for="wgtune">Tune</label>
-                        <input 
-                            class="midiccparam" id="wgtune"  
+                        <input
+                            class="midiccparam" id="wgtune"
                             data-midiChannel="1" data-cclsb="119"
                             max="127" min="0" type="range" />
                     </div>


### PR DESCRIPTION
Hi,

I've left a comment on your YouTube video for this editor, but I just want to say thanks again for sharing your work on this incredibly useful editor!

This pull request includes a couple of suggested changes to the `index.html` file: 

1. I added the missing _Pan parameter_ to the **Processing** section of each Part
2. I added labels to the _wave selection groups_, using the text from Korg's user manual:
**SRC** = Sound Source
**MOD** = Pitch Modulator
**EG** = Amplitude Envelope Generator
These labels may of course be easily changed, but I thought they could be useful for users to be sure of which wave type is being selected.

[Here is a screenshot](https://imgur.com/a/xuehhDo) previewing the changes.

I realize that if the Pan parameter is added, then the `init_patch.js` would also need to be updated to include a default value of **63** (centered pan) for CC #10, but I'm not submitting a pull request for that.

I hope you find these changes useful, and if not then no worries, it was fun having a look through everything and I will be using the edited `index.html` for personal use.

P.S. I noticed that relative directory locations specified in this index.html for the scripts...
    `<script src="../script/ccynthmata.js" type="text/javascript"></script>`
    `<script src="./res/init_patch.js" type="text/javascript"></script>`
... doesn't match their locations in the directory structure of this GitHub repository when downloaded. I didn't make any changes to these though, since these are the correctly working locations specified in your original master `index.html` accessible on the web.