### PR TITLE
Load voice data from MIDI sysex, if compatible message is received.

### DIFF
--- a/script/synthmata.js
+++ b/script/synthmata.js
@@ -56,6 +56,8 @@ function onMIDIFailure(msg) {
 function onMidiMessage(evt) {
     var data    = evt.data;
     if(data[0]!=0xF0)  return;  // only handle SYSEX messages
+    var channel=data[2] & 0xf;
+    if(channel != selectedMidiChannel) return;
     if(!validateSysexData(data)) return;
     loadSysex(data);
     console.log("SYSEX received!");
@@ -468,8 +470,8 @@ function validateSysexData(data) {
         console.log("doesn't end with EOX");
         return false; // doesn't end with EOX
     }
-    if (data[2] & 0x70 != 0) {
-        console.log("sub status is not correct");
+    if ((data[2] & 0x70) != 0) {
+        console.log("sub status is not correct:");
         return false; // sub status is not correct
     }
     if (data[3] != 0) {

--- a/volca-fm/index.html
+++ b/volca-fm/index.html
@@ -116,6 +116,7 @@
                 <div class="controlitemgroup" id="midiSetup">
                     <h3>Midi Device Setup</h3>
                     <p>NB For Volca-FM please leave channel set to '1' as the Volca only listens for patch information on this channel</p>
+                    <p>For Yamaha DX7, leave channel set to '1' if you want to receive voices from the DX7 ('Sysex available' mode), as it always transmits at channel 1.</p>
                 </div>
                 <div class="controlitemgroup" id="saveLoadShare">
                     <h3>Save/Load/Share</h3>


### PR DESCRIPTION
This adds loading SYSEX over MIDI, closing the loop to use Synthmata as a DX7 programmer. 
When sysex information is enabled on the DX7 (must be done after every power on), synthmata will now receive the Patch data on any patch change, eg. selecting the patch on the DX7. This way patches could be edited in the DX7 using synthmata without exporting them before and the result directly stored on the DX7 as usual. Synthmata then only acts like a controller board for all parameters, replacing the extremely costly hardware devices providing hundreds of physical knobs. 